### PR TITLE
Fix custom font test and example

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,10 +193,23 @@ require('postcss-font-magician')({
    custom: {
       'My Special Font': {
          variants: {
-            400: {
-               normal: {
+            normal: {
+               400: {
                   url: {
-                     woff2: 'path/to/my-special-font.woff2'
+                     woff2: 'path/to/my-body-font-normal-400.woff2',
+                     woff: 'path/to/my-body-font-normal-400.woff'
+                  }
+               },
+               700: {
+                  url: {
+                     woff2: 'path/to/my-body-font-normal-700.woff2'
+                  }
+               }
+            },
+            italic: {
+               400: {
+                  url: {
+                     woff2: 'path/to/my-body-font-italic-400.woff2'
                   }
                }
             }

--- a/test/test.js
+++ b/test/test.js
@@ -129,15 +129,15 @@ describe('postcss-font-magician', function () {
 		test(
 			'a{font-family:body}b{}',
 
-			'@font-face{font-family:body;font-style:400;font-weight:normal;src:url(path/to/my-body-font.woff2) format("woff2")}' +
+			'@font-face{font-family:body;font-style:normal;font-weight:400;src:url(path/to/my-body-font.woff2) format("woff2")}' +
 			'a{font-family:body}b{}',
 
 			{
 				custom: {
 					body: {
 						variants: {
-							400: {
-								normal: {
+							normal: {
+								400: {
 									url: {
 										woff2: 'path/to/my-body-font.woff2'
 									}


### PR DESCRIPTION
There was an incorrect order for font-weight and font-style in a custom example. Also, I've added expanded example in the readme, so it's clearer how to use this option.